### PR TITLE
Easy 1059

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
@@ -20,7 +20,7 @@ import java.net.URI
 
 import com.yourmediashelf.fedora.client.FedoraClient
 import com.yourmediashelf.fedora.client.FedoraClient._
-import com.yourmediashelf.fedora.client.request.FedoraRequest
+import com.yourmediashelf.fedora.client.request.{AddDatastream, FedoraRequest}
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang.exception.ExceptionUtils._
@@ -163,23 +163,26 @@ object EasyIngest {
     if (dsSpec.dsLocation != "") {
       request = request.dsLocation(dsSpec.dsLocation)
     } else if (dsSpec.contentFile != "") {
-      request = sdo.listFiles.find(_.getName == dsSpec.contentFile) match {
-        case Some(file) =>
-          if (datastreamId == "EMD") {
-            val placeholder = "$sdo-id"
-            val tmpFile = File.createTempFile(file.getName, null)
-            // Note that this would change the file's checksum, but it is only for the EMD datastream, which has no checksum
-            replacePlaceholderInFileCopy(file, tmpFile, placeholder, pidDictionary(sdo.getName))
-            request.content(tmpFile)
-            val location = request.execute().getLocation
-            FileUtils.deleteQuietly(tmpFile)
-            return Success(location)
-          }
-          request.content(file)
-        case None => throw new RuntimeException(s"Couldn't find specified datastream: ${dsSpec.contentFile}")
+      request = (datastreamId, sdo.listFiles.find(_.getName == dsSpec.contentFile)) match {
+        case ("EMD", Some(file)) =>
+          // Note that this would change the ingested file's checksum, but it is only for the EMD datastream, which has no checksum
+          return Success(executeAddRequestWithReplacement(request, file, "$sdo-id", pidDictionary(sdo.getName)))
+        case (_, Some(file)) => request.content(file)
+        case (_, None) => throw new RuntimeException(s"Couldn't find specified datastream: ${dsSpec.contentFile}")
       }
     }
     request.execute().getLocation
+  }
+
+  private def executeAddRequestWithReplacement(request: AddDatastream, file: File, placeholder: String, replacement:String): URI = {
+    val tmpFile = File.createTempFile(file.getName, null)
+    log.debug(s"Created temp file: '$tmpFile.getAbsolutePath'")
+    replacePlaceholderInFileCopy(file, tmpFile, placeholder, replacement)
+    request.content(tmpFile)
+    val location = request.execute().getLocation
+    log.debug(s"Deleting temp file: '$tmpFile.getAbsolutePath'")
+    FileUtils.deleteQuietly(tmpFile)
+    location
   }
 
   private def replacePlaceholderInFileCopy(src:File, dst:File, placeholder:String, replacement:String): Unit = {

--- a/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
@@ -189,10 +189,10 @@ object EasyIngest {
     // these files are assumed to be small enough to be read into memory without problems
     val srcContent = FileUtils.readFileToString(src)
     if (!srcContent.contains(placeholder))
-      throw new RuntimeException(s"Missing placeholder '$placeholder' in file: $src.getAbsolutePath")
+      throw new RuntimeException(s"Missing placeholder '$placeholder' in file: ${src.getAbsolutePath}")
     val transformedContent = srcContent.replaceAll(placeholder, replacement)
     FileUtils.writeStringToFile(dst, transformedContent)
-    log.debug(s"Replaced placeholder '$placeholder' with '$replacement' while copying from file '$src.getAbsolutePath', to file '$dst.getAbsolutePath'")
+    log.debug(s"Replaced placeholder '$placeholder' with '$replacement' while copying from file '${src.getAbsolutePath}', to file '${dst.getAbsolutePath}'")
   }
 
   private def getFOXML(sdo: File): Try[File] =

--- a/src/main/scala/nl/knaw/dans/easy/ingest/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest/package.scala
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy
+
+import scala.util.{Failure, Success, Try}
+
+package object ingest {
+  implicit class TryExtensions[T](val t: Try[T]) extends AnyVal {
+    def doOnError(f: Throwable => Unit): Try[T] = {
+      t match {
+        case Failure(e) => Try { f(e); throw e }
+        case x => x
+      }
+    }
+
+    def doOnSuccess(f: T => Unit): Try[T] = {
+      t match {
+        case Success(x) => Try { f(x); x }
+        case e => e
+      }
+    }
+
+    def eventually[Ignore](effect: () => Ignore): Try[T] = {
+      t.doOnSuccess(_ => effect()).doOnError(_ => effect())
+    }
+  }
+
+}

--- a/src/test/resources/staged-test1/do1/EMD
+++ b/src/test/resources/staged-test1/do1/EMD
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<emd:easymetadata xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/" emd:version="0.1">
+    <emd:title>TEST DATASET</emd:title>
+    <emd:creator>
+        <eas:creator>
+            <eas:initials>D</eas:initials>
+            <eas:surname>Posit</eas:surname>
+            <eas:organization>DANS</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+        </eas:creator>
+    </emd:creator>
+    <emd:subject/>
+    <emd:description/>
+    <emd:publisher/>
+    <emd:contributor/>
+    <emd:date>
+        <eas:available eas:scheme="W3CDTF" eas:format="DAY">2016-05-31T11:05:52.156+02:00</eas:available>
+    </emd:date>
+    <emd:type>
+        <dc:type eas:scheme="DCMI" eas:schemeId="common.dc.type">Dataset</dc:type>
+    </emd:type>
+    <emd:format/>
+    <emd:identifier>
+        <dc:identifier eas:scheme="DMO_ID">$sdo-id</dc:identifier>
+    </emd:identifier>
+    <emd:source/>
+    <emd:language/>
+    <emd:relation/>
+    <emd:coverage/>
+    <emd:rights>
+        <dct:accessRights eas:schemeId="archaeology.dcterms.accessrights">OPEN_ACCESS</dct:accessRights>
+    </emd:rights>
+    <emd:audience>
+        <dct:audience eas:schemeId="custom.disciplines">easy-discipline:2</dct:audience>
+    </emd:audience>
+    <emd:other>
+        <eas:application-specific>
+            <eas:metadataformat>ARCHAEOLOGY</eas:metadataformat>
+            <eas:pakbon-status>NOT_IMPORTED</eas:pakbon-status>
+        </eas:application-specific>
+        <eas:etc/>
+    </emd:other>
+</emd:easymetadata>

--- a/src/test/resources/staged-test1/do1/cfg.json
+++ b/src/test/resources/staged-test1/do1/cfg.json
@@ -1,7 +1,7 @@
 {
   "namespace" : "easy-dataset",
   "label" : "TEST DATASET",
-  "ownerId" : "alonzo",
+  "ownerId" : "user001",
   "datastreams" : [
     {
       "contentFile" : "license.pdf",
@@ -13,6 +13,10 @@
     },
     {
       "contentFile" : "AMD",
+      "mimeType" : "application/xml"
+    },
+    {
+      "contentFile" : "EMD",
       "mimeType" : "application/xml"
     },
     {


### PR DESCRIPTION
fixes EASY-1059
#### When applied it will
- Before ingesting a dataset's EMD data stream it will replace the placeholder for the Fedora dates id with the 'actual' id given by Fedora when the new dataset 'Fedora object' was created. 
#### Where should the reviewer @DANS-KNAW/easy start?

EasyIngest.addDataStream
#### How should this be manually tested?

ingest a dataset (should have an EMD file with the placeholder) and look into the Fedora archive for the EMD data stream of this dataset's 'Fedora object'. You can do this with the Fedora Admin web interface if you like. The datastream should contain something similar to the following:
`<emd:identifier>
        <dc:identifier eas:scheme="DMO_ID">easy-dataset:1</dc:identifier>
</emd:identifier>`

But instead of `easy-dataset:1` it should state the actual dataset's id
#### related pull requests on github

| repo | PR |
| --- | --- |
| easy-stage-dataset | [PR80](https://github.com/DANS-KNAW/easy-stage-dataset/pull/80) |
