### PR TITLE
EASY-1049 upgrade scallop (and check of readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ A few extra properties and shortcuts are added by ``easy-ingest``:
 ARGUMENTS
 ---------
 
-* ``-u``, ``--user`` -- Fedora user to connect with
+* ``-u``, ``--username`` -- Fedora user to connect with
 * ``-p``, ``--password`` -- password of the Fedora user
 * ``-f``, ``--fcrepo-server`` -- URL of the Fedora Commons Repository server
 * ``-i``, ``--init`` -- initialize the directory as an SDO instead of ingesting it

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.yourmediashelf.fedora.client</groupId>

--- a/src/main/scala/nl/knaw/dans/easy/ingest/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest/Conf.scala
@@ -15,12 +15,15 @@
  */
 package nl.knaw.dans.easy.ingest
 
-import org.apache.commons.configuration.PropertiesConfiguration
-import org.rogach.scallop.ScallopConf
-import java.io.File
 import java.net.URL
 
+import org.apache.commons.configuration.PropertiesConfiguration
+import org.rogach.scallop.ScallopConf
+
 class Conf(args: Seq[String], props: PropertiesConfiguration) extends ScallopConf(args) {
+  appendDefaultToDescription = true
+  editBuilder(_.setHelpWidth(110))
+
   printedName = "easy-ingest"
   val indent_____ = printedName.replaceAll(".", " ")
   version(s"$printedName v${Version()}")
@@ -29,28 +32,30 @@ class Conf(args: Seq[String], props: PropertiesConfiguration) extends ScallopCon
                 |
                 |Usage:
                 |
-                | $printedName [-u <user> -p <password>] [-f <fcrepo-server>][-i] \\
+                | $printedName [-u <user> -p <password>] [-f <fcrepo-server>] [-i] \\
                 | $indent_____ [<staged-digital-object>... | <staged-digital-object-set>]
                 |
                 |Options:
                 |""".stripMargin)
+  private val s = " provided, please check {{app.home}}/cfg/application.properties"
+  val fedoraUrl = opt[URL](name = "fcrepo-server",
+    descr = "URL of the Fedora Commons Repository Server",
+    default = props.getString("default.fcrepo-server") match {
+      case s: String => Some(new URL(s))
+      case _ =>
+        throw new RuntimeException("No valid default Fedora Commons URL" + s)
+    })
   val username = opt[String]("username",
     descr = "Username to use for authentication/authorisation to the Fedora Commons Repository Server",
     default = props.getString("default.user") match {
       case s: String => Some(s)
-      case _ => throw new RuntimeException("No username provided")
+      case _ => throw new RuntimeException("No default username" + s)
     })
   val password = opt[String]("password",
     descr = "Password to use for authentication/authorisation to the Fedora Commons Repository Server",
     default = props.getString("default.password") match {
       case s: String => Some(s)
-      case _ => throw new RuntimeException("No password provided")
-    })
-  val fedoraUrl = opt[URL](name = "fcrepo-server",
-    descr = "URL of the Fedora Commons Repository Server",
-    default = props.getString("default.fcrepo-server") match {
-      case s: String => Some(new URL(s))
-      case _ => throw new RuntimeException("No Fedora Commons URL provided")
+      case _ => throw new RuntimeException("No default password" + s)
     })
   val init = opt[Boolean](name = "init",
     descr = "Initialize template SDO instead of ingesting",
@@ -60,5 +65,5 @@ class Conf(args: Seq[String], props: PropertiesConfiguration) extends ScallopCon
     name = "<staged-digital-object-(set)>",
     descr = "Either a single Staged Digital Object or a set of SDO's",
     required = true)
- 
+  verify()
 } 

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>[%-5level] %msg %n</Pattern>
+        </encoder>
+    </appender>
+    <root level="error">
+        <appender-ref ref="CONSOLE" />
+    </root>
+    <logger name="nl.knaw.dans.easy.stage" level="off" />
+</configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <Pattern>[%-5level] %msg %n</Pattern>
-        </encoder>
-    </appender>
-    <root level="error">
-        <appender-ref ref="CONSOLE" />
-    </root>
-    <logger name="nl.knaw.dans.easy.stage" level="off" />
+
+    <!-- No logging during the build -->
+    <root level="off" />
+
 </configuration>

--- a/src/test/scala/nl/knaw/dans/easy/ingest/ConfSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/ingest/ConfSpec.scala
@@ -1,18 +1,18 @@
 /**
-  * Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *         http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+ * Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.ingest
 import java.io.{ByteArrayOutputStream, File}
 

--- a/src/test/scala/nl/knaw/dans/easy/ingest/ConfSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/ingest/ConfSpec.scala
@@ -25,7 +25,7 @@ class ConfSpec extends FlatSpec with Matchers {
 
 
   val helpInfo = {
-    val propsFile = new File("tearget/test/application.properties")
+    val propsFile = new File("target/test/application.properties")
     FileUtils.write(propsFile, "default.fcrepo-server=http://deasy.dans.knaw.nl:8080/fedora\n" +
       "default.user=u\n" +
       "default.password=p")

--- a/src/test/scala/nl/knaw/dans/easy/ingest/ConfSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/ingest/ConfSpec.scala
@@ -1,0 +1,61 @@
+/**
+  * Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *         http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package nl.knaw.dans.easy.ingest
+import java.io.{ByteArrayOutputStream, File}
+
+import nl.knaw.dans.easy.ingest.CustomMatchers._
+import org.apache.commons.configuration.PropertiesConfiguration
+import org.apache.commons.io.FileUtils
+import org.scalatest.{FlatSpec, Matchers}
+
+class ConfSpec extends FlatSpec with Matchers {
+
+
+  val helpInfo = {
+    val propsFile = new File("tearget/test/application.properties")
+    FileUtils.write(propsFile, "default.fcrepo-server=http://deasy.dans.knaw.nl:8080/fedora\n" +
+      "default.user=u\n" +
+      "default.password=p")
+    val props = new PropertiesConfiguration(propsFile)
+    propsFile.delete()
+
+    val mockedStdOut = new ByteArrayOutputStream()
+    Console.withOut(mockedStdOut) {
+      new Conf("args".split(" "), props).printHelp()
+    }
+    mockedStdOut.toString
+  }
+
+  /* check for options in help info is spoilt by links in readme
+   * and defaults from {{app.home}}/cfg/application.properties
+   * requiring a semantically valid fedora URL
+   */
+  ignore should "be part of README.md" in {
+    val options = helpInfo.replaceAll("\\(default[^)]+\\)","").split("Options:")(1)
+    new File("README.md") should containTrimmed(options)
+  }
+
+  "synopsis in help info" should "be part of README.md" in {
+    val synopsis = helpInfo.split("Options:")(0).split("Usage:")(1)
+    new File("README.md") should containTrimmed(synopsis)
+  }
+
+  "first banner line" should "be part of README.md and pom.xml" in {
+    val description = helpInfo.split("\n")(1)
+    new File("README.md") should containTrimmed(description)
+    new File("pom.xml") should containTrimmed(description)
+  }
+}

--- a/src/test/scala/nl/knaw/dans/easy/ingest/CustomMatchers.scala
+++ b/src/test/scala/nl/knaw/dans/easy/ingest/CustomMatchers.scala
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.ingest
+
+import java.io.{FileInputStream, File}
+
+import org.apache.commons.io.FileUtils._
+import org.apache.commons.io.IOUtils
+import org.scalatest.matchers.{MatchResult, Matcher}
+import org.scalatest.words.ResultOfATypeInvocation
+
+import scala.util.{Success, Failure, Try}
+
+
+/** See also <a href="http://www.scalatest.org/user_guide/using_matchers#usingCustomMatchers">CustomMatchers</a> */
+trait CustomMatchers {
+
+  class ContentMatcher(content: String) extends Matcher[File] {
+    def apply(left: File) = {
+      def trimLines(s: String): String = s.split("\n").map(_.trim).mkString("\n")
+      MatchResult(
+        trimLines(readFileToString(left)).contains(trimLines(content)),
+        s"$left did not contain: $content" ,
+        s"$left contains $content"
+      )
+    }
+  }
+
+  /** usage example: new File(...) should containTrimmed("...") */
+  def containTrimmed(content: String) = new ContentMatcher(content)
+}
+
+object CustomMatchers extends CustomMatchers


### PR DESCRIPTION
fixes EASY-1049: Upgrade scallop
#### When applied it will
- use the version 1.0.1 of scallop
- improve the stack trace when trying `run.sh --help` is tried without a valid `{{app.home}}/cfg/application.properties`
#### Where should the reviewer @DANS-KNAW/easy start?

Conf and ConfSpec
#### How should this be manually tested?
- execute `./run.sh --help` without providing app.home
- the cause in the stack trace should explain the problem
#### related pull requests on github

| repo | PR |
| --- | --- |
| easy-satge-dataset | [74](https://github.com/DANS-KNAW/easy-stage-dataset/pull/74) |
