### PR TITLE
integrate license generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,16 @@
             <version>1.0.1</version>
         </dependency>
         <dependency>
+            <groupId>nl.knaw.dans.easy</groupId>
+            <artifactId>ddm</artifactId>
+            <version>2.14-beta-5</version>
+        </dependency>
+        <dependency>
+            <groupId>nl.knaw.dans.easy</groupId>
+            <artifactId>easy-license-creator</artifactId>
+            <version>1.x-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.yourmediashelf.fedora.client</groupId>
             <artifactId>fedora-client-core</artifactId>
         </dependency>

--- a/src/main/scala/nl/knaw/dans/easy/ingest/Settings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest/Settings.scala
@@ -18,15 +18,22 @@ package nl.knaw.dans.easy.ingest
 import java.io.File
 
 import com.yourmediashelf.fedora.client.FedoraCredentials
+import nl.knaw.dans.easy.ingest.Settings.AdministrativeMetadata
+import nl.knaw.dans.pf.language.emd.EasyMetadata
+
+import scala.xml.Elem
 
 object Settings{
+  type AdministrativeMetadata = Elem
   def apply(conf: Conf): Settings =
     new Settings(
-      new FedoraCredentials(conf.fedoraUrl(), conf.username(), conf.password()),
-      new File(conf.sdo()),
-      conf.init())
+      fedoraCredentials = new FedoraCredentials(conf.fedoraUrl(), conf.username(), conf.password()),
+      sdo = new File(conf.sdo()),
+      init = conf.init())
 }
 
-case class Settings(fedoraCredentials: FedoraCredentials,
+case class Settings(emd: Option[EasyMetadata] = None,
+                    amd: Option[AdministrativeMetadata] = None,
+                    fedoraCredentials: FedoraCredentials,
                     sdo: File,
                     init: Boolean = false)


### PR DESCRIPTION
fixes EASY-1063
#### When applied it will
- add a license to a new dataset
- add a new version of an existing dataset including the new file 
#### Where should the reviewer @DANS-KNAW/easy start?
- [ ] Fix all the `???` (not implemented), comment gives hints where to find the missing information.
#### How should this be manually tested?
- run `easy-ingest-flow` with some valid bag, check with the web-ui a license is available in the new dataset.
- run `easy-ingest` from the command line with the output of easy-stage-dataset, the dataset won't yet appear in search list, but with the logged dataset-id you can try to examine the license of the new dataset.
- run `easy-ingest` from the command line with the output of easy-stage-file-item, in this case fedora should store another version of the license.pdf
#### related pull requests on github

| repo | PR | note |
| --- | --- | --- |
| easy-ingest-flow | [#43](https://github.com/DANS-KNAW/easy-ingest-flow/pull/43) | mutual dependent |
