### PR TITLE
bugfix: Close input streams

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,6 @@ fixes EASY-
 #### How should this be manually tested?
 
 #### related pull requests on github
-repo                       | PR
--------------------------- | -----------------
-easy-                      | [PR#](PRlink) 
+repo                       | PR                | note
+-------------------------- | ----------------- | ---
+easy-                      | [PR#](PRlink)     | 

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.jsuereth</groupId>
+            <artifactId>scala-arm_2.11</artifactId>
+            <version>2.0.0-M1</version>
+        </dependency>
+        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.11</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
        <groupId>nl.knaw.dans.shared</groupId>
        <artifactId>dans-scala-prototype</artifactId>
-       <version>1.27</version>
+       <version>1.28</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-ingest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
         <dependency>
             <groupId>com.jsuereth</groupId>
             <artifactId>scala-arm_2.11</artifactId>
-            <version>2.0.0-M1</version>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
@@ -208,7 +208,7 @@ object EasyIngest {
     request.execute().getLocation
   }
 
-  private def replacePlaceHolder(file: File, placeholder: String, replacement:String): ByteArrayInputStream = {
+  private def replacePlaceHolder(file: File, placeholder: String, replacement:String): InputStream = {
     // these files are assumed to be small enough to be read into memory without problems
     val originalContent = FileUtils.readFileToString(file, "UTF-8")
     require(originalContent.contains(placeholder), s"Missing placeholder '$placeholder' in file: ${file.getAbsolutePath}")

--- a/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
@@ -128,7 +128,7 @@ object EasyIngest {
       sdo <- sdos
       _ = log.debug(s"Adding datastreams for $sdo")
       dsSpec <- configDictionary(sdo.getName).datastreams
-    } yield addDataStream(sdo, dsSpec, pidDictionary)).collectResults().recoverWith{
+    } yield addDataStream(sdo, dsSpec, pidDictionary(sdo.getName))).collectResults().recoverWith{
       case e =>
         partialFailure(pidDictionary, s"but failed to add datastream(s) ${e.getMessage}", e)
     }
@@ -180,28 +180,27 @@ object EasyIngest {
 
   private def pidToUri(pid: String): String = s"info:fedora/$pid"
 
-  private def addDataStream(sdo: File, dsSpec: DatastreamSpec, pidDictionary: PidDictionary): Try[URI] = Try {
+  private def addDataStream(sdo: File, dsSpec: DatastreamSpec, pid: Pid): Try[URI] = Try {
     log.debug(s"Getting datastreamId from spec: $dsSpec")
-    val datastreamId = (dsSpec.dsID, dsSpec.contentFile, dsSpec.dsLocation) match {
-      case (id, _, _) if id != "" => id
-      case ("", file, _) if file != "" => file
+    val datastreamId = (dsSpec.dsID, dsSpec.contentFile) match {
+      case (id, _) if id.nonEmpty => id
+      case ("", file) if file.nonEmpty => file
       case _ => throw new RuntimeException(s"Invalid datastream specification provided in ${sdo.getName}")
     }
 
     log.debug(s"Adding datastream with dsId = $datastreamId")
-    var request = addDatastream(pidDictionary(sdo.getName), datastreamId).mimeType(dsSpec.mimeType).controlGroup(dsSpec.controlGroup)
+    val request = addDatastream(pid, datastreamId).mimeType(dsSpec.mimeType).controlGroup(dsSpec.controlGroup)
 
-    if (dsSpec.checksumType != "" && dsSpec.checksum != "")
-      request = request.checksumType(dsSpec.checksumType).checksum(dsSpec.checksum)
+    if (dsSpec.checksumType.nonEmpty && dsSpec.checksum.nonEmpty)
+      request.checksumType(dsSpec.checksumType).checksum(dsSpec.checksum)
 
-    if (dsSpec.dsLocation != "") {
-      request = request.dsLocation(dsSpec.dsLocation)
-    } else if (dsSpec.contentFile != "") {
-      request = (datastreamId, sdo.listFiles.find(_.getName == dsSpec.contentFile)) match {
+    if (dsSpec.dsLocation.nonEmpty) {
+      request.dsLocation(dsSpec.dsLocation)
+    } else if (dsSpec.contentFile.nonEmpty) {
+      (datastreamId, sdo.listFiles.find(_.getName == dsSpec.contentFile)) match {
         case ("EMD", Some(file)) =>
           // Note that this would change the ingested file's checksum, but it is only for the EMD datastream, which has no checksum
-          managed(replacePlaceHolder(file, PLACEHOLDER_FOR_DMO_ID, pidDictionary(sdo.getName)))
-            .acquireAndGet(request.content)
+          managed(replacePlaceHolder(file, PLACEHOLDER_FOR_DMO_ID, pid)).acquireAndGet(request.content)
         case (_, Some(file)) => request.content(file)
         case (_, None) => throw new RuntimeException(s"Couldn't find specified datastream: ${dsSpec.contentFile}")
       }


### PR DESCRIPTION
fixes EASY-
#### When applied it will
- not suffer from too many unnecessary resources
#### Where should the reviewer @DANS-KNAW/easy start?

[managed(stream).acquireAndGet(function)](https://github.com/DANS-KNAW/easy-ingest/compare/master...jo-pol:close-input-streams?expand=1#diff-eb57f1153d904b1e8c9e539928333553R203) is the essential change. The managed stream is passed on to function.
#### How should this be manually tested?
#### related pull requests on github

| repo | PR | note |
| --- | --- | --- |
| dans-parent | [#20](https://github.com/DANS-KNAW/dans-parent/pull/20) | easy-ingest needs this change |
