### PR TITLE
Scala lib collectResults refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
        <groupId>nl.knaw.dans.shared</groupId>
        <artifactId>dans-scala-prototype</artifactId>
-       <version>1.32</version>
+       <version>1.33</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-ingest</artifactId>
@@ -81,7 +81,6 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib</artifactId>
-            <version>1.x-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.11</artifactId>
         </dependency>
+        <dependency>
+            <groupId>nl.knaw.dans.lib</groupId>
+            <artifactId>dans-scala-lib</artifactId>
+            <version>1.x-SNAPSHOT</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
@@ -128,7 +128,7 @@ object EasyIngest {
       sdo <- sdos
       _ = log.debug(s"Adding datastreams for $sdo")
       dsSpec <- configDictionary(sdo.getName).datastreams
-    } yield addDataStream(sdo, dsSpec, pidDictionary(sdo.getName))).collectResults.recoverWith{
+    } yield addDataStream(sdo, dsSpec, pidDictionary(sdo.getName))).collectResults.recoverWith {
       case e =>
         partialFailure(pidDictionary, s"but failed to add datastream(s) ${e.getMessage}", e)
     }
@@ -141,7 +141,7 @@ object EasyIngest {
       log.debug(s"Adding relations for sdo $sdo")
       val relations = configDictionary(sdo.getName).relations
       relations.map(addRelation(sdo.getName, pidDictionary))
-    }).collectResults.recoverWith{
+    }).collectResults.recoverWith {
       case e =>
         partialFailure(pidDictionary, s"but failed to add relation(s) ${e.getMessage}", e)
     }


### PR DESCRIPTION
@DANS-KNAW/easy 
- adds _dans-scala-lib_ as a dependency
- refactors the use of `sequence` or `collectResults` to use the library implementation
