### PR TITLE
changed version of json4s dependency to the project's default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-native_2.11</artifactId>
-            <version>3.2.11</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
@DANS-KNAW/easy for review

For some reason I get a `NoSuchMethodError` on runtime (on deasy) with the `3.2.11` version of json4s. Since this is an old version, which overrides the newer version in one of the parent projects, I decided to remove it. This also (I have no clue why) solved the runtime error...
