### PR TITLE
EASY-1141, fix problem with invalid dsLocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ out/
 /.settings
 /.classpath
 /.cache
+*.sc

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ out/
 /.classpath
 /.cache
 *.sc
+

--- a/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.ingest
 
 import java.io._
-import java.net.URI
+import java.net.{URI, URLEncoder}
 
 import com.yourmediashelf.fedora.client.FedoraClient._
 import com.yourmediashelf.fedora.client.request.FedoraRequest
@@ -195,7 +195,7 @@ object EasyIngest {
       request = request.checksumType(dsSpec.checksumType).checksum(dsSpec.checksum)
 
     (
-      if (dsSpec.dsLocation.nonEmpty) request.dsLocation(dsSpec.dsLocation)
+      if (dsSpec.dsLocation.nonEmpty) request.dsLocation(URLEncoder.encode(dsSpec.dsLocation, "UTF-8"))
       else if (dsSpec.contentFile.isEmpty) request
       else (datastreamId, sdo.listFiles.find(_.getName == dsSpec.contentFile)) match {
         case ("EMD", Some(file)) =>


### PR DESCRIPTION
Fixes EASY-1141
#### When applied it will
-  make sure percent-encoding is always applied on `dsLocation` parameters to Fedora, so that valid URLs are not saved as invalid ones.
#### Where should the reviewer @DANS-KNAW/easy start?

Only one line changed.
#### How should this be manually tested?

See JIRA issue.
