### PR TITLE
add datastream, set to non-versionable 

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest/EasyIngest.scala
@@ -189,7 +189,7 @@ object EasyIngest {
     }
 
     log.debug(s"Adding datastream with dsId = $datastreamId")
-    var request = addDatastream(pid, datastreamId).mimeType(dsSpec.mimeType).controlGroup(dsSpec.controlGroup)
+    var request = addDatastream(pid, datastreamId).versionable(false).mimeType(dsSpec.mimeType).controlGroup(dsSpec.controlGroup)
 
     if (dsSpec.checksumType.nonEmpty && dsSpec.checksum.nonEmpty)
       request = request.checksumType(dsSpec.checksumType).checksum(dsSpec.checksum)


### PR DESCRIPTION
I don't know why I didn't notice this earlier, but the default when adding datastreams is to make them versionable, while we don't currently do that with objects ingested through the Web-UI.
