### PR TITLE
EASY-1375: replace dataset placeholder in relation

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.ingest/EasyIngest.scala
+++ b/src/main/scala/nl.knaw.dans.easy.ingest/EasyIngest.scala
@@ -167,7 +167,7 @@ object EasyIngest extends DebugEnhancedLogging {
     val subjectPid: Pid = pidDictionary(subjectName)
     val objectPid = (if (relation.`object` != "") relation.`object`
                      else pidToUri(pidDictionary(relation.objectSDO)))
-      .replace("$sdo-id", subjectPid)
+      .replace(PLACEHOLDER_FOR_DMO_ID, subjectPid)
     val request = FedoraClient.addRelationship(subjectPid)
       .predicate(relation.predicate)
       .`object`(objectPid, relation.isLiteral)

--- a/src/main/scala/nl.knaw.dans.easy.ingest/EasyIngest.scala
+++ b/src/main/scala/nl.knaw.dans.easy.ingest/EasyIngest.scala
@@ -163,10 +163,11 @@ object EasyIngest extends DebugEnhancedLogging {
       }
   }
 
-  private def addRelation(subjectName: String, pidDictionary: PidDictionary)(relation: Relation)(implicit fedora: FedoraClient): Try[(Pid, String, Pid)] = {
+  private def addRelation(subjectName: String, pidDictionary: PidDictionary)(relation: Relation)(implicit fedora: FedoraClient): Try[(Pid, String, String)] = {
     val subjectPid: Pid = pidDictionary(subjectName)
-    val objectPid = if (relation.`object` != "") relation.`object`
-                    else pidToUri(pidDictionary(relation.objectSDO))
+    val objectPid = (if (relation.`object` != "") relation.`object`
+                     else pidToUri(pidDictionary(relation.objectSDO)))
+      .replace("$sdo-id", subjectPid)
     val request = FedoraClient.addRelationship(subjectPid)
       .predicate(relation.predicate)
       .`object`(objectPid, relation.isLiteral)


### PR DESCRIPTION
fixes EASY-1375

#### When applied it will
* replace the `$sdo-id` placeholder with the dataset identifier (`easy-dataset:XXX`)

@DANS-KNAW/easy for review

#### Related pull request
* https://github.com/DANS-KNAW/easy-stage-dataset/pull/129