### PR TITLE
EASY-1996: add extra PIDs to the PidDictionary from the command line

### DIFF
--- a/command/src/main/scala/nl.knaw.dans.easy.ingest.command/CommandLineOptions.scala
+++ b/command/src/main/scala/nl.knaw.dans.easy.ingest.command/CommandLineOptions.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.ingest.command
 
+import java.io.File
+
 import org.rogach.scallop.{ ScallopConf, ScallopOption }
 
 class CommandLineOptions(args: Seq[String], configuration: Configuration) extends ScallopConf(args) {
@@ -25,7 +27,11 @@ class CommandLineOptions(args: Seq[String], configuration: Configuration) extend
   printedName = "easy-ingest"
   version(s"$printedName ${ configuration.version }")
   val description = "Ingest Staged Digital Objects (SDO's) into a Fedora Commons 3.x repository."
-  val synopsis = s"$printedName [-i] [<staged-digital-object> | <staged-digital-object-set>]"
+  val synopsis =
+    s"""
+       |  $printedName [-i] [<staged-digital-object> | <staged-digital-object-set>]
+       |  $printedName [-p <extraPids>] [<staged-digital-object> | <staged-digital-object-set>]
+       |""".stripMargin
   banner(
     s"""
        |$description
@@ -41,11 +47,22 @@ class CommandLineOptions(args: Seq[String], configuration: Configuration) extend
   val init: ScallopOption[Boolean] = opt[Boolean](name = "init",
     descr = "Initialize template SDO instead of ingesting",
     default = Some(false),
-    required = false)
+    required = false,
+    short = 'i',
+  )
+  val extraPids: ScallopOption[File] = opt[File](name = "extraPids",
+    descr = "Properties file containing extra key-value pairs for the PidDictionary that is being put together while running this application.",
+    required = false,
+    short = 'p',
+  )
   val sdo: ScallopOption[String] = trailArg[String](
     name = "<staged-digital-object-(set)>",
     descr = "Either a single Staged Digital Object or a set of SDO's",
-    required = true)
+    required = true,
+  )
+
+  validateFileExists(extraPids)
+  validateFileIsFile(extraPids)
 
   verify()
 } 

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,6 +116,56 @@ A few extra properties and shortcuts are added by ``easy-ingest``:
     - "objectSDO" is the name of an SDO in the same SDO-set. ``easy-ingest`` will fill in the resulting Fedora PID here.
 
 
+### Extra PIDs
+
+When an extra file needs to be ingested and linked to an existing dataset, the `--extraPids` option can be used. For example:
+
+Given a dataset `easy-dataset:1` that is already ingested and a staged file object `MY_FILE` with a `cfg.json` containing a
+`relation` with `objectSDO` referring to the dataset.
+
+```json
+{
+  "namespace":"easy-file",
+  "datastreams":[{
+    "contentFile":"EASY_FILE",
+    "dsID":"EASY_FILE",
+    "controlGroup":"M",
+    "mimeType":"text/plain",
+    "checksumType":"SHA-1",
+    "checksum":"4f5ea58e1c7e617f2190f7d9cf33637bc14aae02"
+  },{
+    "contentFile":"EASY_FILE_METADATA",
+    "dsID":"EASY_FILE_METADATA",
+    "controlGroup":"X",
+    "mimeType":"text/xml"
+  }],
+  "relations":[{
+    "predicate":"http://dans.knaw.nl/ontologies/relations#isMemberOf",
+    "objectSDO":"DATASET_SDO~~RESERVED"
+  },{
+    "predicate":"http://dans.knaw.nl/ontologies/relations#isSubordinateTo",
+    "objectSDO":"DATASET_SDO~~RESERVED"
+  },{
+    "predicate":"info:fedora/fedora-system:def/model#hasModel",
+    "object":"info:fedora/easy-model:EDM1FILE"
+  },{
+    "predicate":"info:fedora/fedora-system:def/model#hasModel",
+    "object":"info:fedora/dans-container-item-v1"
+  }]
+}
+```
+
+The goal is for `MY_FILE` to be ingested into Fedora, and linked to `easy-dataset:1`.
+Create a `extra-pids.properties` file with content:
+
+```properties
+DATASET_SDO~~RESERVED = easy-dataset:1
+```
+
+Now run `easy-ingest --extraPids extra-pids.properties MY_FILE` and `MY_FILE` will be ingested into Fedora and the
+`DATASET_SDO~~RESERVED` key will be replaced by `easy-dataset:1` in the relation(s).
+
+
 ARGUMENTS
 ---------
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ SYNOPSIS
 --------
 
     easy-ingest [-i] [<staged-digital-object> | <staged-digital-object-set>]
+    easy-ingest [-p <extraPids>] [<staged-digital-object> | <staged-digital-object-set>]
 
 
 DESCRIPTION
@@ -118,9 +119,11 @@ A few extra properties and shortcuts are added by ``easy-ingest``:
 ARGUMENTS
 ---------
 
-     -i, --init      Initialize template SDO instead of ingesting
-     -h, --help      Show help message
-     -v, --version   Show version of this program
+     -p, --extraPids  <arg>   Properties file containing extra key-value pairs for the PidDictionary that is
+                              being put together while running this application.
+     -i, --init               Initialize template SDO instead of ingesting
+     -h, --help               Show help message
+     -v, --version            Show version of this program
 
     trailing arguments:
      <staged-digital-object-(set)> (required)   Either a single Staged Digital Object or a set of SDO's

--- a/lib/src/main/scala/nl.knaw.dans.easy.ingest/Settings.scala
+++ b/lib/src/main/scala/nl.knaw.dans.easy.ingest/Settings.scala
@@ -23,10 +23,12 @@ case class Settings(fedoraCredentials: FedoraCredentials,
                     sdo: File,
                     init: Boolean = false,
                     foTemplate: File,
-                    cfgTemplate: File) {
+                    cfgTemplate: File,
+                    extraPids: PidDictionary = Map.empty,
+                   ) {
 
   override def toString: String = {
     s"ingest.Settings(Fedora(${ fedoraCredentials.getBaseUrl }, ${ fedoraCredentials.getUsername }, " +
-      s"****), sdo = $sdo, init = $init, fo-template = $foTemplate, cfg-template = $cfgTemplate)"
+      s"****), sdo = $sdo, init = $init, fo-template = $foTemplate, cfg-template = $cfgTemplate, extraPids = $extraPids)"
   }
 }


### PR DESCRIPTION
part of EASY-1996

#### When applied it will
* add extra Pids to the PidDictionary from the command line

#### How should this be manually tested?
* turn off `easy-ingest-flow`
* deposit a bag via `easy-sword2` and `easy-sword2-dans-examples`
* find the deposit in `easy-ingest-flow-inbox` and move it to `/home/vagrant`
* just to be sure, run `easy-validate-dans-bag /home/vagrant/<depositId>/<bag>/`
* generate a DOI: `curl -X POST http://localhost:20140/create?type=doi`
* generate a URN: `curl -X POST http://localhost:20140/create?type=urn`
* run `mkdir /home/vagrant/staging-dir`
* run `easy-stage-dataset -u '<URN>' -d '<DOI>' /home/vagrant/<depositId>/ /home/vagrant/staging-dir/`
* run `easy-ingest /home/vagrant/staging-dir/DATASET_SDO~~RESERVED/`
  * save the returned FedoraId (`easy-dataset:xxx`)
* run `mv /home/vagrant/staging-dir/DATASET_SDO~~RESERVED /home/vagrant/`
* run `echo "DATASET_SDO~~RESERVED = <FedoraId>" > /home/vagrant/extra-pids.properties`
* run `easy-ingest -p /home/vagrant/extra-pids.properties /home/vagrant/staging-dir/`
* go to http://deasy.dans.knaw.nl:8080/fedora/risearch and run the following SPARQL query: `select ?s from <#ri> where { ?s <http://dans.knaw.nl/ontologies/relations#isSubordinateTo> <info:fedora/<FedoraId>> . }`

@DANS-KNAW/easy for review